### PR TITLE
Fix `default: stdin: is not a tty` error for the `vagrant up` command

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -124,4 +124,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # chef-validator, unless you changed the configuration.
   #
   #   chef.validation_client_name = "ORGNAME-validator"
+  
+  # Fix `default: stdin: is not a tty` error for the `vagrant up` command (See issue #5)
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 end


### PR DESCRIPTION
See issue #5.
